### PR TITLE
Fix a typo found in README.md (s/shellschoccar/shellshoccar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ hello
 * awk
 * netcat
 * socat
-* mime-make(@shellschoccarjpn)
+* mime-make(@shellshoccarjpn)
 
 ## LICENSE
 This software is released under the MIT License, see LICENSE


### PR DESCRIPTION
些細なことですが、シェルショッカーのTwitter ID が間違っていたので修正しました。
プログラムスキルはほぼゼロですがすこしでもLit、ひいてはPOSIX原理主義の健全な発展にお力添えできれば幸いです。